### PR TITLE
Updated to use "Course" of CCE from "Department" of CCE

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,0 +1,7 @@
+# -*- mode: perl; -*-
+$latex = 'platex %O -synctex=1 %S -interaction=batchmode';
+$bibtex = 'pbibtex';
+$dvipdf = 'dvipdfmx %O -o %D %S';
+$pdflatex = 'pdflatex %O -synctex=1 %S -interaction=batchmode';
+$makeindex = 'mendex -U %O -o %D %S';
+$pdf_mode = 3;

--- a/cover-en.tex
+++ b/cover-en.tex
@@ -8,8 +8,7 @@
 \AUTHOR{John Smith}
 
 \SUPERVISOR{Prof. Anony Mous}
-% For master thesis
-\DEPARTMENT{Communication and Computer Engineering}
+\COURSE{Communication and Computer Engineering}
 
 \ENTRANCEMONTHYEAR{10}{2001}  %% year in AD
 \COMPLETIONMONTHYEAR{9}{2008}

--- a/cover-en.tex
+++ b/cover-en.tex
@@ -8,6 +8,7 @@
 \AUTHOR{John Smith}
 
 \SUPERVISOR{Prof. Anony Mous}
+% For master thesis
 \DEPARTMENT{Communication and Computer Engineering}
 
 \ENTRANCEMONTHYEAR{10}{2001}  %% year in AD

--- a/cover.tex
+++ b/cover.tex
@@ -1,4 +1,7 @@
-\documentclass{jarticle}
+% For bachelor thesis
+% \documentclass{jarticle}
+% For master thesis
+\documentclass[master]{jarticle}
 \usepackage{kuis-cover}
 
 \begin{document}
@@ -8,7 +11,10 @@
 \AUTHOR{山田 太郎}
 
 \SUPERVISOR{佐藤 花子 教授}
-\DEPARTMENT{計算機科学}
+% For bachelor thesis
+% \DEPARTMENT{計算機科学}
+% For master thesis
+\DEPARTMENT{通信情報システム}
 
 \ENTRANCEMONTHYEAR{4}{2016}
 \COMPLETIONMONTHYEAR{3}{2020}

--- a/cover.tex
+++ b/cover.tex
@@ -12,9 +12,9 @@
 
 \SUPERVISOR{佐藤 花子 教授}
 % For bachelor thesis
-% \DEPARTMENT{計算機科学}
+% \COURSE{計算機科学}
 % For master thesis
-\DEPARTMENT{通信情報システム}
+\COURSE{通信情報システム}
 
 \ENTRANCEMONTHYEAR{4}{2016}
 \COMPLETIONMONTHYEAR{3}{2020}

--- a/kuis-cover.sty
+++ b/kuis-cover.sty
@@ -125,7 +125,7 @@
 \def\MKT@MASTERTHESIS{Master's Thesis}
 \def\MKT@SUPERVISOR{Supervisor}
 \def\MKT@MASTERSCHOOL{Graduate School of Informatics, Kyoto University}
-\def\MKT@MASTERDEPARTMENT{Department of {\@DEPARTMENT}, Master's Program}
+\def\MKT@MASTERDEPARTMENT{Course of {\@DEPARTMENT}, Master's Program}
 \else
 \def\MKT@BACHELORTHESIS{特別研究報告書}
 \def\MKT@MASTERTHESIS{修士論文}
@@ -133,7 +133,7 @@
 \def\MKT@BACHELORSCHOOL{京都大学工学部情報学科}
 \def\MKT@MASTERSCHOOL{京都大学大学院情報学研究科}
 \def\MKT@BACHELORDEPARTMENT{{\@DEPARTMENT}コース}
-\def\MKT@MASTERDEPARTMENT{{\@DEPARTMENT}専攻 修士課程}
+\def\MKT@MASTERDEPARTMENT{{\@DEPARTMENT}コース 修士課程}
 \def\MKT@BACHELORGRADUATE{卒業}
 \def\MKT@MASTERGRADUATE{修了}
 \fi

--- a/kuis-cover.sty
+++ b/kuis-cover.sty
@@ -45,7 +45,7 @@
 
 \def\AUTHOR#1{\gdef\@AUTHOR{#1}}
 \def\SUPERVISOR#1{\gdef\@SUPERVISOR{#1}}
-\def\DEPARTMENT#1{\gdef\@DEPARTMENT{#1}}
+\def\COURSE#1{\gdef\@COURSE{#1}}
 
 \def\ENTRANCEMONTHYEAR#1#2{%
  \setcounter{ENTRANCEMONTH}{#1}%
@@ -121,27 +121,43 @@
   \fi%
  \fi}
 
-\ifDS@en
+\ifDS@en%
 \def\MKT@MASTERTHESIS{Master's Thesis}
 \def\MKT@SUPERVISOR{Supervisor}
 \def\MKT@MASTERSCHOOL{Graduate School of Informatics, Kyoto University}
-\def\MKT@MASTERDEPARTMENT{Course of {\@DEPARTMENT}, Master's Program}
+\def\MKT@MASTERCOURSE{Course of {\@COURSE},}
+\def\MKT@MASTERDEPARTMENT{Department of Informatics, Master's Program}
 \else
 \def\MKT@BACHELORTHESIS{特別研究報告書}
 \def\MKT@MASTERTHESIS{修士論文}
 \def\MKT@SUPERVISOR{指導教員}
 \def\MKT@BACHELORSCHOOL{京都大学工学部情報学科}
-\def\MKT@MASTERSCHOOL{京都大学大学院情報学研究科}
-\def\MKT@BACHELORDEPARTMENT{{\@DEPARTMENT}コース}
-\def\MKT@MASTERDEPARTMENT{{\@DEPARTMENT}コース 修士課程}
+\def\MKT@MASTERSCHOOL{京都大学大学院情報学研究科 修士課程}
+\def\MKT@BACHELORCOURSE{{\@COURSE}コース}
+\def\MKT@MASTERCOURSE{{\@COURSE}コース}
+\def\MKT@MASTERDEPARTMENT{{情報学専攻}}
 \def\MKT@BACHELORGRADUATE{卒業}
 \def\MKT@MASTERGRADUATE{修了}
 \fi
 
 \def\MKT@THESIS{\ifDS@master{\MKT@MASTERTHESIS}\else{\MKT@BACHELORTHESIS}\fi}
-\def\MKT@DEPARTMENT{%
-\ifDS@master{\MKT@MASTERSCHOOL}\else{\MKT@BACHELORSCHOOL}\fi \\%
-\ifDS@master{\MKT@MASTERDEPARTMENT}\else{\MKT@BACHELORDEPARTMENT}\fi}
+\def\MKT@COURSE{%
+\ifDS@en%
+\ifDS@master%
+\MKT@MASTERCOURSE\\ %
+\MKT@MASTERDEPARTMENT \\%
+\MKT@MASTERSCHOOL%
+\fi
+\else
+\ifDS@master%
+\MKT@MASTERSCHOOL\\ %
+\MKT@MASTERDEPARTMENT{ }\MKT@MASTERCOURSE%
+\else
+\MKT@BACHELORSCHOOL\\ %
+\MKT@BACHELORCOURSE%
+\fi \\%
+\fi
+}
 \def\MKT@GRADUATE{\ifDS@master{\MKT@MASTERGRADUATE}\else{\MKT@BACHELORGRADUATE}\fi}
 
 \def\MAKETITLE{{%
@@ -166,7 +182,7 @@
    \vfill\vfill\vfill
    \CL{\large
     \vbox{\halign{\hfil ##\hfil\cr%
-     \MKT@DEPARTMENT\crcr}}}%
+     \MKT@COURSE\crcr}}}%
    \vskip.5cm
    \CL{\large
     \vbox{\halign{\hfil ##\hfil\cr%


### PR DESCRIPTION
I have updated the style file for the change of "Course of CCE" from "Department of CCE".

English/master: [cover-en.pdf](https://github.com/user-attachments/files/18452881/cover-en.pdf)
Japanese/Master: [cover.pdf](https://github.com/user-attachments/files/18452882/cover.pdf)
Japanese/Bachelor: [cover.pdf](https://github.com/user-attachments/files/18452886/cover.pdf)
